### PR TITLE
I find this description:

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -32,6 +32,14 @@ gem 'sdoc', '~> 0.4.0', group: :doc
 # Use Capistrano for deployment
 # gem 'capistrano-rails', group: :development
 
+#	SiOleskR
+# I must add this line to work in my localhost. 
+# May require (in cmd ruby in the project directory):
+# bundle update
+
+gem 'tzinfo-data'
+gem 'coffee-script-source', '1.8.0'
+
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -47,7 +47,7 @@ GEM
     coffee-script (2.4.1)
       coffee-script-source
       execjs
-    coffee-script-source (1.10.0)
+    coffee-script-source (1.8.0)
     concurrent-ruby (1.0.2)
     debug_inspector (0.0.2)
     erubis (2.7.0)
@@ -74,6 +74,8 @@ GEM
     minitest (5.9.1)
     multi_json (1.12.1)
     nokogiri (1.6.8.1)
+      mini_portile2 (~> 2.1.0)
+    nokogiri (1.6.8.1-x64-mingw32)
       mini_portile2 (~> 2.1.0)
     rack (1.6.5)
     rack-test (0.6.3)
@@ -124,6 +126,7 @@ GEM
       activesupport (>= 4.0)
       sprockets (>= 3.0.0)
     sqlite3 (1.3.12)
+    sqlite3 (1.3.12-x64-mingw32)
     thor (0.19.1)
     thread_safe (0.3.5)
     tilt (2.0.5)
@@ -132,6 +135,8 @@ GEM
     turbolinks-source (5.0.0)
     tzinfo (1.2.2)
       thread_safe (~> 0.1)
+    tzinfo-data (1.2016.9)
+      tzinfo (>= 1.0.0)
     uglifier (3.0.3)
       execjs (>= 0.3.0, < 3)
     web-console (2.3.0)
@@ -142,10 +147,12 @@ GEM
 
 PLATFORMS
   ruby
+  x64-mingw32
 
 DEPENDENCIES
   byebug
   coffee-rails (~> 4.1.0)
+  coffee-script-source (= 1.8.0)
   jbuilder (~> 2.0)
   jquery-rails
   rails (= 4.2.5)
@@ -154,6 +161,7 @@ DEPENDENCIES
   spring
   sqlite3
   turbolinks
+  tzinfo-data
   uglifier (>= 1.3.0)
   web-console (~> 2.0)
 

--- a/app/helpers/home_helper.rb
+++ b/app/helpers/home_helper.rb
@@ -1,2 +1,3 @@
 module HomeHelper
+  
 end

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -1,32 +1,5 @@
-<div id="cookieinfo" class="cookieinfo">
-	<div class="cookieinfowarstwanosna" style="display:none;">
-		<div class="cookieinfowarstwatekstu">
-			Używamy cookies m.in. w celach zapewnienia maksymalnej wygody użytkowników przy korzystaniu z naszej strony (zapamiętywanie preferencji i ustawień na naszych stronach, zbieranie anonimowych danych dla celów statystycznych). Korzystanie z witryny bez zmiany
-			ustawień Twojej przeglądarki oznacza, że będą one umieszczane w Twoim urządzeniu końcowym. Pamiętaj, że zawsze możesz zmienić te ustawienia.
-		</div>
-		<img src="/assets/zamknij.png" alt="" class="cookieinfozamknij" onclick="document.getElementById(&quot;cookieinfo&quot;).style.display=&quot;none&quot;;setCookie(&quot;cookieinfo&quot;,&quot;potwierdzone&quot;,365);" />
-	</div>
-</div>
-<div class="bialygornypasek"></div>
-<div class="nazwafirmy">Pomysly.online</div>
-<div class="menu">
-	<div class="menustart"></div>
-	<div class="menumiddle">
-		<div class="menuodstep">
-			<a href="." class="menuglowne">Strona główna</a>
-			<div class="separatormenu">|</div>
-			<a href="produkty,index,spis" class="menuglowne">Produkty</a>
-			<div class="separatormenu">|</div>
-			<a href="staticpages,index,pokaz,kontakt" class="menuglowne">Kontakt</a>
-		</div>
-	</div>
-	<div class="menustop"></div>
-</div>
 <div class="srodek">
-	<link rel="Stylesheet" type="text/css" />W przygotowaniu</div>
-<div class="stopka">
-	<div>Wszelke prawa zastrzeżone dla Terrabit Janusz Hess. Projekt i realizacja 
-		<a href="http://www.drukarnia.infopres.pl" onclick="window.open(&quot;http://www.drukarnia.infopres.pl&quot;,&quot;chaild&quot;);return false;" class="stopka">
-				www.drukarnia.infopres.pl</a>
-	</div>
+	In progress
 </div>
+
+

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -21,7 +21,44 @@
 </head>
 <body>
 
+<div class="bialygornypasek"></div>
+
+<div class="nazwafirmy">Pomysly.online</div>
+
+<div id="menu">
+  <div class='menu'>
+         <div class='menustart'></div>
+         <div class='menumiddle'>
+           <div class='menuodstep'>
+             <a href='.' class='menuglowne'>Strona główna</a>
+             <div class='separatormenu'>|</div>
+             <a href='products' class='menuglowne'>Produkty</a>
+             <div class='separatormenu'>|</div>
+             <a href='staticpages,index,pokaz,kontakt' class='menuglowne'>Kontakt</a>
+           </div>
+         </div>
+         <div class='menustop'></div>
+     </div>
+</div>
+
 <%= yield %>
+
+<div class="stopka">
+	<div>Wszelke prawa zastrzeżone dla Terrabit Janusz Hess. Projekt i realizacja 
+		<a href="http://www.drukarnia.infopres.pl" onclick="window.open(&quot;http://www.drukarnia.infopres.pl&quot;,&quot;chaild&quot;);return false;" class="stopka">
+				www.drukarnia.infopres.pl</a>
+	</div>
+</div>
+
+<div id="cookieinfo" class="cookieinfo">
+	<div class="cookieinfowarstwanosna" style="display:none;">
+		<div class="cookieinfowarstwatekstu">
+			Używamy cookies m.in. w celach zapewnienia maksymalnej wygody użytkowników przy korzystaniu z naszej strony (zapamiętywanie preferencji i ustawień na naszych stronach, zbieranie anonimowych danych dla celów statystycznych). Korzystanie z witryny bez zmiany
+			ustawień Twojej przeglądarki oznacza, że będą one umieszczane w Twoim urządzeniu końcowym. Pamiętaj, że zawsze możesz zmienić te ustawienia.
+		</div>
+		<img src="/assets/zamknij.png" alt="" class="cookieinfozamknij" onclick="document.getElementById(&quot;cookieinfo&quot;).style.display=&quot;none&quot;;setCookie(&quot;cookieinfo&quot;,&quot;potwierdzone&quot;,365);" />
+	</div>
+</div>
 
 </body>
 </html>


### PR DESCRIPTION
"Rails uses layouts as master templates. As default will you have one
master layout template called application, which you can find in
app/views/layouts/application.html.erb.

As default will this be rendered for all pages, and the content of each
page would be rendered in the yield block.

This means that application.html.erb is the right place to but generel
layout stuff, like menus and banners that should appear on all pages.

If you want to have something that varies a bit for each page (fx
different banners) can you add a special <%= yield(:banner) if
content_for?(:banner) %> in your application.html.erb file. You will
then be able to add a block in each of your pages for a banner like
this:

# app/views/some_resource/some_page.html.erb
<% content_for(:banner) do %>
  # insert page specifik banner here
<% end %>
# normal content for page
..."